### PR TITLE
Rewrite sign in, show error and no claims messaging on frontend

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -22,15 +22,8 @@ const STYLES = (theme: ThemeVariables) => ({
 export class AppComponent {
   readonly classes = this.theme.addStyleSheet(STYLES);
 
-  auth: AuthService = null;
-
-  constructor(private theme: LyTheme2, private AuthService: AuthService) {
-    this.auth = AuthService;
-  }
+  constructor(private theme: LyTheme2, public auth: AuthService) {}
 
   ngOnInit() {
-    if (localStorage.getItem('isLoggedIn') === 'true') {
-      this.auth.renewTokens();
-    }
   }
 }

--- a/frontend/src/app/auth/auth-guard.service.ts
+++ b/frontend/src/app/auth/auth-guard.service.ts
@@ -9,7 +9,7 @@ export class AuthGuardService {
   constructor(public authService: AuthService, public router: Router) {}
 
   canActivate(): boolean {
-    if (!this.authService.isAuthenticated()) {
+    if (!this.authService.loggedIn) {
       this.authService.login();
       return false;
     }

--- a/frontend/src/app/auth/auth.config.ts
+++ b/frontend/src/app/auth/auth.config.ts
@@ -1,0 +1,17 @@
+import { ENV } from 'src/app/core/env.config';
+
+interface AuthConfig {
+    CLIENT_ID: string;
+    CLIENT_DOMAIN: string;
+    AUDIENCE: string;
+    REDIRECT: string;
+    SCOPE: string;
+};
+
+export const AUTH_CONFIG: AuthConfig = {
+    CLIENT_ID: 't3sXyFtDUl0wFsHVsQsJbEa4en4bgPly',
+    CLIENT_DOMAIN: 'total-loss-process.auth0.com',
+    AUDIENCE: 'https://total-loss-process.auth0.com/api/v2/',
+    REDIRECT: `${ENV.BASE_URI}/callback`,
+    SCOPE: 'openid profile create:user_app_metadata update:user_app_metadata read:users'
+};

--- a/frontend/src/app/callback/callback.component.html
+++ b/frontend/src/app/callback/callback.component.html
@@ -1,3 +1,3 @@
 <p>
-  callback works!
+  Loading...
 </p>

--- a/frontend/src/app/callback/callback.component.ts
+++ b/frontend/src/app/callback/callback.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../auth/auth.service';
 import { Router } from '@angular/router';
-import { CookieService } from 'ngx-cookie-service';
 
 @Component({
   selector: 'app-callback',
@@ -9,12 +8,15 @@ import { CookieService } from 'ngx-cookie-service';
   styleUrls: ['./callback.component.scss']
 })
 export class CallbackComponent implements OnInit {
-  constructor(private auth: AuthService, private router: Router, private cookie: CookieService) { }
+  constructor(private auth: AuthService, private router: Router) {
+    auth.handleAuth();
 
-  ngOnInit() {
-    this.auth.handleAuthentication();
 
-    this.router.navigate(['']);
-  }
+   }
 
+   ngOnInit() {}
+
+   generateKeys(): void {
+     
+   }
 }

--- a/frontend/src/app/core/env.config.ts
+++ b/frontend/src/app/core/env.config.ts
@@ -1,0 +1,13 @@
+const isDev = window.location.port.indexOf('4200') > -1;
+const getHost = () => {
+    const protocol = window.location.protocol;
+    const host = window.location.host;
+    return `${protocol}//${host}`;
+}
+
+const apiUri = isDev ? 'http://localhost:8080' : '/prod-url-tbd';
+
+export const ENV = {
+    BASE_URI: getHost(),
+    BASE_API: apiUri
+};

--- a/frontend/src/app/header/header.component.html
+++ b/frontend/src/app/header/header.component.html
@@ -21,22 +21,20 @@
                 <button 
                   ly-button color="accent" 
                   class="mll float-right" 
-                  *ngIf="authService.isAuthenticated()"
-                  (click)="authService.logout()"
+                  *ngIf="auth.loggedIn"
+                  (click)="auth.logout()"
                   >
                     Log Out
                 </button>
                 <button 
                   ly-button color="accent" 
                   class="mll float-right" 
-                  *ngIf="!authService.isAuthenticated()"
-                  (click)="authService.login()"
+                  *ngIf="!auth.loggedIn"
+                  (click)="auth.login()"
                   >
                     Log In
                 </button>
             </ly-grid>
         </ly-grid>
     </ly-toolbar>
-    
-    
 </header>

--- a/frontend/src/app/header/header.component.scss
+++ b/frontend/src/app/header/header.component.scss
@@ -1,4 +1,3 @@
-
 .toolbar-override-header {
     padding-top: 5px;
     padding-bottom: 10px;

--- a/frontend/src/app/header/header.component.ts
+++ b/frontend/src/app/header/header.component.ts
@@ -7,14 +7,10 @@ import { AuthService } from '../auth/auth.service';
   styleUrls: ['./header.component.scss']
 })
 export class HeaderComponent implements OnInit {
-  authService: AuthService = null;
 
-  constructor(private Auth: AuthService) {
-    this.authService = Auth;
-   }
-
-  ngOnInit() {
-    
+  constructor(public auth: AuthService) {
   }
+
+  ngOnInit() {}
 
 }

--- a/frontend/src/app/home/home.component.html
+++ b/frontend/src/app/home/home.component.html
@@ -1,6 +1,6 @@
 <div class="center-text">
-  <h2 lyTyp="display2" gutterBottom *ngIf="isAuthenticated() && user">
-    Hello, {{ user.firstName }}
+  <h2 lyTyp="display2" gutterBottom *ngIf="auth.loggedIn">
+    Hello, {{ (auth.userProfile) ? auth.userProfile.name : 'friend'  }}!
   </h2>
   <a
     routerLink="/new-claim"

--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -13,21 +13,14 @@ export class HomeComponent implements OnInit {
   user: User;
 
   constructor(
-    private auth: AuthService,
+    public auth: AuthService,
     private middleware: MiddlewareService,
   ) {}
 
   ngOnInit() {
-    if (this.isAuthenticated()) {
-      this.user = this.auth.getUser();
+    if (this.auth.loggedIn) {
+      console.log(this.auth.userProfile);
+      this.user = this.auth.userProfile;
     }
-  }
-
-  isAuthenticated(): boolean {
-    if (this.auth.isAuthenticated()) {
-      return true;
-    }
-
-    return false;
   }
 }

--- a/frontend/src/app/middleware/middleware.service.ts
+++ b/frontend/src/app/middleware/middleware.service.ts
@@ -18,9 +18,10 @@ export class MiddlewareService {
   constructor(private http: HttpClient, private auth: AuthService) {}
 
   get user() {
-    if (this.auth.isAuthenticated()) {
-      return this.auth.getUser();
+    if (this.auth.loggedIn) {
+      return this.auth.userProfile;
     }
+    
     throw new Error('User needs to be logged in');
   }
 

--- a/frontend/src/app/view-claims/view-claims.component.html
+++ b/frontend/src/app/view-claims/view-claims.component.html
@@ -1,12 +1,27 @@
 <div>
   <ly-grid container [spacing]="16">
-    <ly-grid item [col]="6" *ngFor="let claim of claims">
-      <ly-paper [withClass]="classes.paper" [elevation]="2">
-        <h3 [lyTyp]="'title'">{{ claim.vehicle.vin }}</h3>
-        <p [lyTyp]="'body1'">Vehicle Model: {{ claim.vehicle.model }}</p>
-        <p [lyTyp]="'body1'">Vehicle Color: {{ claim.vehicle.color }}</p>
-        <p [lyTyp]="'body1'">Claim Status: {{ claim.vehicle.status }}</p>
-      </ly-paper>
-    </ly-grid>
+    <ng-template *ngIf="claims >= 0; else noClaims">
+      <ly-grid item [col]="6" *ngFor="let claim of claims">
+        <ly-paper [withClass]="classes.paper" [elevation]="2">
+          <h3 [lyTyp]="'title'">{{ claim.vehicle.vin }}</h3>
+          <p [lyTyp]="'body1'">Vehicle Model: {{ claim.vehicle.model }}</p>
+          <p [lyTyp]="'body1'">Vehicle Color: {{ claim.vehicle.color }}</p>
+          <p [lyTyp]="'body1'">Claim Status: {{ claim.status }}</p>
+        </ly-paper>
+      </ly-grid>
+    </ng-template>
   </ly-grid>
+
+  <ng-template #noClaims>
+      <ly-paper [withClass]="classes.noClaims" [elevation]="2">
+        <h3 [lyTyp]="'title'">No claims to view</h3>
+      </ly-paper>
+  </ng-template>
+
+  <ng-template *ngIf="responseError">
+    <ly-paper [withClass]="classes.noClaims" [elevation]="2">
+      <h3 [lyTyp]="'title'">Error getting Claims!</h3>
+      <p>{{ errorText }}</p>
+    </ly-paper>
+  </ng-template>
 </div>

--- a/frontend/src/app/view-claims/view-claims.component.ts
+++ b/frontend/src/app/view-claims/view-claims.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { LyTheme2 } from '@alyle/ui';
 import { MiddlewareService } from '../middleware/middleware.service';
 import { AuthService } from '../auth/auth.service';
+import { LySnackBarDismiss } from '@alyle/ui/snack-bar';
+import { LySnackBarModule } from '@alyle/ui/snack-bar';
 
 const STYLES = {
   paper: {
@@ -9,6 +11,11 @@ const STYLES = {
     margin: '.5em',
     padding: '1em',
   },
+  noClaims: {
+    display: 'block',
+    margin: '3rem auto auto auto',
+    padding: '1em',
+  }
 };
 
 @Component({
@@ -20,6 +27,8 @@ export class ViewClaimsComponent implements OnInit {
   readonly classes = this._theme.addStyleSheet(STYLES);
 
   private claims: Protos.Claim[];
+  private responseError: boolean;
+  private errorText: string;
 
   constructor(
     private _theme: LyTheme2,
@@ -28,47 +37,27 @@ export class ViewClaimsComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    if (this.auth.isAuthenticated()) {
-      this.middlewareService.getClaims().subscribe(data => {
-        this.claims = data;
-      });
-    } else {
-      // FIXME: Pitch this
-      this.claims = [
-        {
-          files: [],
-          status: 0,
-          vehicle: {
-            vin: '112233445566',
-            model: 'TEST MODEL 1',
-            color: 'TEST COLOR 1',
-            year: 2001,
-            miles: 100000,
-          },
-        },
-        {
-          files: [],
-          status: 0,
-          vehicle: {
-            vin: '223344556677',
-            model: 'TEST MODEL 2',
-            color: 'TEST COLOR 2',
-            year: 2002,
-            miles: 200000,
-          },
-        },
-        {
-          files: [],
-          status: 0,
-          vehicle: {
-            vin: '334455667788',
-            model: 'TEST MODEL 3',
-            color: 'TEST COLOR 3',
-            year: 2003,
-            miles: 300000,
-          },
-        },
-      ];
+    if (this.auth.loggedIn) {
+      this.setClaims();
     }
+  }
+
+  afterDismissed(e: LySnackBarDismiss) {
+    console.log(e);
+  }
+
+  setClaims(): void {
+    this.middlewareService.getClaims().subscribe(
+      result => { this.claims = result; },
+      error => { 
+        this.responseError = true; 
+        this.errorText = error;
+      },
+      () => {});
+  }
+
+  openSnackBar() {
+
+    
   }
 }


### PR DESCRIPTION
Sign in now maintains user login state after refreshing page - EXCEPT for Social logins (Google)

When no claims are on the chain, "No claims are available" is displayed.
If error getting claims, error messaging is shown.