### PR TITLE
Draft for add claims endpoint

### DIFF
--- a/middleware/lib/utils/s3.js
+++ b/middleware/lib/utils/s3.js
@@ -14,7 +14,7 @@ const s3 = new S3({
  *
  * @param {string} vin - The VIN
  */
-const getBucketName = vin => `ford-capstone-wayne-state/${vin}`;
+const getBucketName = vin => `ford-capstone-wayne-state.${vin}`;
 
 /**
  * @typedef {import('aws-sdk').AWSError} AWSError

--- a/middleware/routes/claims.js
+++ b/middleware/routes/claims.js
@@ -44,11 +44,25 @@ router.post('/', authMiddleware, async (req, res) => {
   }
 });
 
+
 // Edit an existing claim on the blockchain using VIN.
 router.post('/:vin', authMiddleware, async (req, res) => {
   try {
     const client = new ClaimClient(req.privateKey);
     const response = await client.editClaim(req.params.vin, req.body);
+    console.log(response);
+    res.send(response);
+  } catch (err) {
+    console.log(err);
+    res.sendStatus(500);
+  }
+});
+
+// Add images to a claim using the Detailed Claim view.
+router.post('/:vin/:files', authMiddleware, async (req, res) => {
+  try {
+    const client = new ClaimClient(req.privateKey);
+    const response = await client.addFiles(req.params.vin, req.params.files);
     console.log(response);
     res.send(response);
   } catch (err) {


### PR DESCRIPTION
Used '.' instead of '/' for bucket name, because '/' gives this error:
InvalidBucket: Bucket names cannot contain forward slashes. Bucket: ford-capstone-wayne-state/123123123123