### PR TITLE
update protos

### DIFF
--- a/middleware/lib/__tests__/claim-client.test.js
+++ b/middleware/lib/__tests__/claim-client.test.js
@@ -18,12 +18,25 @@ const api = require('../api');
 jest.mock('../api');
 
 describe('ClaimClient', () => {
+  /**
+   * @type {DeepPartial<Protos.Claim> & { vehicle: { vin: string } }}
+   */
   const CLAIM = {
-    files: [],
     status: 0,
+    created: new Date(Date.UTC(2019, 1)).toJSON(),
+    modified: new Date(Date.UTC(2019, 0)).toJSON(),
+    date_of_loss: new Date(Date.UTC(2019, 0)).toJSON(),
     vehicle: {
       vin: '12345678910',
+      miles: 0,
+      location: '',
     },
+    insurer: {
+      name: '',
+      deductible: 0,
+      has_gap: false,
+    },
+    files: [],
   };
 
   /**
@@ -54,7 +67,9 @@ describe('ClaimClient', () => {
 
     it('should edit claims correctly', async () => {
       await expect(
-        client.editClaim(CLAIM.vehicle.vin, { vehicle: { color: 'red' } }),
+        client.editClaim(CLAIM.vehicle.vin, {
+          vehicle: { location: 'salvage' },
+        }),
       ).resolves;
     });
 
@@ -68,9 +83,9 @@ describe('ClaimClient', () => {
 
     it('should throw InvalidTransaction with invalid claim data', async () => {
       /** @type {any} */
-      const claim = { vehicle: { color: Symbol('Red') } };
+      const claim = { vehicle: { location: Symbol('Red') } };
       await expect(client.editClaim(CLAIM.vehicle.vin, claim)).rejects.toThrow(
-        new InvalidTransaction('data.vehicle.color: string expected'),
+        new InvalidTransaction('data.vehicle.location: string expected'),
       );
     });
 
@@ -105,10 +120,7 @@ describe('ClaimClient', () => {
           ...CLAIM,
           vehicle: {
             ...CLAIM.vehicle,
-            color: '',
             miles: 0,
-            model: '',
-            year: 0,
           },
         },
       ]);
@@ -120,10 +132,7 @@ describe('ClaimClient', () => {
         ...CLAIM,
         vehicle: {
           ...CLAIM.vehicle,
-          color: '',
           miles: 0,
-          model: '',
-          year: 0,
         },
       });
       await expect(client.getClaim('asdf')).rejects.toThrowError();

--- a/middleware/lib/utils/proto.js
+++ b/middleware/lib/utils/proto.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 
-const { load } = require('protobufjs');
+const { Root } = require('protobufjs');
 
 const readdir = promisify(fs.readdir);
 
@@ -23,7 +23,8 @@ exports.loadRoot = async () => {
   const protos = await readdir(protosPath).then(files =>
     files.map(name => path.join(protosPath, name)),
   );
-  return load(protos);
+  const root = new Root();
+  return root.load(protos, { keepCase: true });
 };
 
 /**
@@ -32,7 +33,7 @@ exports.loadRoot = async () => {
  * @param {string} typename - The name of the type to load.
  * @return {Promise<ProtobufType>}
  */
-exports.loadType = async (typename) => {
+exports.loadType = async typename => {
   const Root = await exports.loadRoot();
   return Root.lookupType(typename);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,32 +189,32 @@
       }
     },
     "@jest/core": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.3.1.tgz",
-      "integrity": "sha512-orucOIBKfXgm1IJirtPT0ToprqDVGYKUNJKNc9a6v1Lww6qLPq+xj5OfxyhpJb2rWOgzEkATW1bfZzg3oqV70w==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.5.0.tgz",
+      "integrity": "sha512-RDZArRzAs51YS7dXG1pbXbWGxK53rvUu8mCDYsgqqqQ6uSOaTjcVyBl2Jce0exT2rSLk38ca7az7t2f3b0/oYQ==",
       "dev": true,
       "requires": {
         "@jest/console": "^24.3.0",
-        "@jest/reporters": "^24.3.1",
-        "@jest/test-result": "^24.3.0",
-        "@jest/transform": "^24.3.1",
-        "@jest/types": "^24.3.0",
+        "@jest/reporters": "^24.5.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/transform": "^24.5.0",
+        "@jest/types": "^24.5.0",
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.15",
-        "jest-changed-files": "^24.3.0",
-        "jest-config": "^24.3.1",
-        "jest-haste-map": "^24.3.1",
-        "jest-message-util": "^24.3.0",
+        "jest-changed-files": "^24.5.0",
+        "jest-config": "^24.5.0",
+        "jest-haste-map": "^24.5.0",
+        "jest-message-util": "^24.5.0",
         "jest-regex-util": "^24.3.0",
-        "jest-resolve-dependencies": "^24.3.1",
-        "jest-runner": "^24.3.1",
-        "jest-runtime": "^24.3.1",
-        "jest-snapshot": "^24.3.1",
-        "jest-util": "^24.3.0",
-        "jest-validate": "^24.3.1",
-        "jest-watcher": "^24.3.0",
+        "jest-resolve-dependencies": "^24.5.0",
+        "jest-runner": "^24.5.0",
+        "jest-runtime": "^24.5.0",
+        "jest-snapshot": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jest-validate": "^24.5.0",
+        "jest-watcher": "^24.5.0",
         "micromatch": "^3.1.10",
         "p-each-series": "^1.0.0",
         "pirates": "^4.0.1",
@@ -230,26 +230,26 @@
           "dev": true
         },
         "jest-validate": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.3.1.tgz",
-          "integrity": "sha512-ww3+IPNCOEMi1oKlrHdSnBXetXtdrrdSh0bqLNTVkWglduhORf94RJWd1ko9oEPU2TcEQS5QIPacYziQIUzc4A==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
+          "integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "camelcase": "^5.0.0",
             "chalk": "^2.0.1",
             "jest-get-type": "^24.3.0",
             "leven": "^2.1.0",
-            "pretty-format": "^24.3.1"
+            "pretty-format": "^24.5.0"
           }
         },
         "pretty-format": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
-          "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+          "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "ansi-regex": "^4.0.0",
             "ansi-styles": "^3.2.0",
             "react-is": "^16.8.4"
@@ -258,40 +258,40 @@
       }
     },
     "@jest/environment": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.3.1.tgz",
-      "integrity": "sha512-M8bqEkQqPwZVhMMFMqqCnzqIZtuM5vDMfFQ9ZvnEfRT+2T1zTA4UAOH/V4HagEi6S3BCd/mdxFdYmPgXf7GKCA==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.5.0.tgz",
+      "integrity": "sha512-tzUHR9SHjMXwM8QmfHb/EJNbF0fjbH4ieefJBvtwO8YErLTrecc1ROj0uo2VnIT6SlpEGZnvdCK6VgKYBo8LsA==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^24.3.0",
-        "@jest/transform": "^24.3.1",
-        "@jest/types": "^24.3.0",
+        "@jest/fake-timers": "^24.5.0",
+        "@jest/transform": "^24.5.0",
+        "@jest/types": "^24.5.0",
         "@types/node": "*",
-        "jest-mock": "^24.3.0"
+        "jest-mock": "^24.5.0"
       }
     },
     "@jest/fake-timers": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.3.0.tgz",
-      "integrity": "sha512-rHwVI17dGMHxHzfAhnZ04+wFznjFfZ246QugeBnbiYr7/bDosPD2P1qeNjWnJUUcfl0HpS6kkr+OB/mqSJxQFg==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.5.0.tgz",
+      "integrity": "sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.3.0",
+        "@jest/types": "^24.5.0",
         "@types/node": "*",
-        "jest-message-util": "^24.3.0",
-        "jest-mock": "^24.3.0"
+        "jest-message-util": "^24.5.0",
+        "jest-mock": "^24.5.0"
       }
     },
     "@jest/reporters": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.3.1.tgz",
-      "integrity": "sha512-jEIDJcvk20ReUW1Iqb+prlAcFV+kfFhQ/01poCq8X9As7/l/2y1GqVwJ3+6SaPTZuCXh0d0LVDy86zDAa8zlVA==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.5.0.tgz",
+      "integrity": "sha512-vfpceiaKtGgnuC3ss5czWOihKOUSyjJA4M4udm6nH8xgqsuQYcyDCi4nMMcBKsHXWgz9/V5G7iisnZGfOh1w6Q==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.3.1",
-        "@jest/test-result": "^24.3.0",
-        "@jest/transform": "^24.3.1",
-        "@jest/types": "^24.3.0",
+        "@jest/environment": "^24.5.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/transform": "^24.5.0",
+        "@jest/types": "^24.5.0",
         "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "glob": "^7.1.2",
@@ -299,11 +299,11 @@
         "istanbul-lib-coverage": "^2.0.2",
         "istanbul-lib-instrument": "^3.0.1",
         "istanbul-lib-source-maps": "^3.0.1",
-        "jest-haste-map": "^24.3.1",
-        "jest-resolve": "^24.3.1",
-        "jest-runtime": "^24.3.1",
-        "jest-util": "^24.3.0",
-        "jest-worker": "^24.3.1",
+        "jest-haste-map": "^24.5.0",
+        "jest-resolve": "^24.5.0",
+        "jest-runtime": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jest-worker": "^24.4.0",
         "node-notifier": "^5.2.1",
         "slash": "^2.0.0",
         "source-map": "^0.6.0",
@@ -338,32 +338,32 @@
       }
     },
     "@jest/test-result": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.3.0.tgz",
-      "integrity": "sha512-j7UZ49T8C4CVipEY99nLttnczVTtLyVzFfN20OiBVn7awOs0U3endXSTq7ouPrLR5y4YjI5GDcbcvDUjgeamzg==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.5.0.tgz",
+      "integrity": "sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==",
       "dev": true,
       "requires": {
         "@jest/console": "^24.3.0",
-        "@jest/types": "^24.3.0",
+        "@jest/types": "^24.5.0",
         "@types/istanbul-lib-coverage": "^1.1.0"
       }
     },
     "@jest/transform": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.3.1.tgz",
-      "integrity": "sha512-PpjylI5goT4Si69+qUjEeHuKjex0LjjrqJzrMYzlOZn/+SCumGKuGC0UQFeEPThyGsFvWH1Q4gj0R66eOHnIpw==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.5.0.tgz",
+      "integrity": "sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^24.3.0",
+        "@jest/types": "^24.5.0",
         "babel-plugin-istanbul": "^5.1.0",
         "chalk": "^2.0.1",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.1.15",
-        "jest-haste-map": "^24.3.1",
+        "jest-haste-map": "^24.5.0",
         "jest-regex-util": "^24.3.0",
-        "jest-util": "^24.3.0",
+        "jest-util": "^24.5.0",
         "micromatch": "^3.1.10",
         "realpath-native": "^1.1.0",
         "slash": "^2.0.0",
@@ -380,9 +380,9 @@
       }
     },
     "@jest/types": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.3.0.tgz",
-      "integrity": "sha512-VoO1F5tU2n/93QN/zaZ7Q8SeV/Rj+9JJOgbvKbBwy4lenvmdj1iDaQEPXGTKrO6OSvDeb2drTFipZJYxgo6kIQ==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.5.0.tgz",
+      "integrity": "sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^1.1.0",
@@ -446,9 +446,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
-      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==",
+      "version": "11.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
+      "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -684,13 +684,13 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.3.1.tgz",
-      "integrity": "sha512-6KaXyUevY0KAxD5Ba+EBhyfwvc+R2f7JV7BpBZ5T8yJGgj0M1hYDfRhDq35oD5MzprMf/ggT81nEuLtMyxfDIg==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
+      "integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^24.3.1",
-        "@jest/types": "^24.3.0",
+        "@jest/transform": "^24.5.0",
+        "@jest/types": "^24.5.0",
         "@types/babel__core": "^7.1.0",
         "babel-plugin-istanbul": "^5.1.0",
         "babel-preset-jest": "^24.3.0",
@@ -1562,16 +1562,16 @@
       }
     },
     "expect": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-24.3.1.tgz",
-      "integrity": "sha512-xnmobSlaqhg4FKqjb5REk4AobQzFMJoctDdREKfSGqrtzRfCWYbfqt3WmikAvQz/J8mCNQhORgYdEjPMJbMQPQ==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-24.5.0.tgz",
+      "integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.3.0",
+        "@jest/types": "^24.5.0",
         "ansi-styles": "^3.2.0",
         "jest-get-type": "^24.3.0",
-        "jest-matcher-utils": "^24.3.1",
-        "jest-message-util": "^24.3.0",
+        "jest-matcher-utils": "^24.5.0",
+        "jest-message-util": "^24.5.0",
         "jest-regex-util": "^24.3.0"
       },
       "dependencies": {
@@ -2538,31 +2538,31 @@
       }
     },
     "jest": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-24.3.1.tgz",
-      "integrity": "sha512-SqZguEbYNcZ3r0KUUBN+IkKfyPS1VBbIUiK4Wrc0AiGUR52gJa0fmlWSOCL3x25908QrfoQwkVDu5jCsfXb2ig==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-24.5.0.tgz",
+      "integrity": "sha512-lxL+Fq5/RH7inxxmfS2aZLCf8MsS+YCUBfeiNO6BWz/MmjhDGaIEA/2bzEf9q4Q0X+mtFHiinHFvQ0u+RvW/qQ==",
       "dev": true,
       "requires": {
         "import-local": "^2.0.0",
-        "jest-cli": "^24.3.1"
+        "jest-cli": "^24.5.0"
       },
       "dependencies": {
         "jest-cli": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.3.1.tgz",
-          "integrity": "sha512-HdwMgigvDQdlWX7gwM2QMkJJRqSk7tTYKq7kVplblK28RarqquJMWV/lOCN8CukuG9u3DZTeXpCDXR7kpGfB3w==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.5.0.tgz",
+          "integrity": "sha512-P+Jp0SLO4KWN0cGlNtC7JV0dW1eSFR7eRpoOucP2UM0sqlzp/bVHeo71Omonvigrj9AvCKy7NtQANtqJ7FXz8g==",
           "dev": true,
           "requires": {
-            "@jest/core": "^24.3.1",
-            "@jest/test-result": "^24.3.0",
-            "@jest/types": "^24.3.0",
+            "@jest/core": "^24.5.0",
+            "@jest/test-result": "^24.5.0",
+            "@jest/types": "^24.5.0",
             "chalk": "^2.0.1",
             "exit": "^0.1.2",
             "import-local": "^2.0.0",
             "is-ci": "^2.0.0",
-            "jest-config": "^24.3.1",
-            "jest-util": "^24.3.0",
-            "jest-validate": "^24.3.1",
+            "jest-config": "^24.5.0",
+            "jest-util": "^24.5.0",
+            "jest-validate": "^24.5.0",
             "prompts": "^2.0.1",
             "realpath-native": "^1.1.0",
             "yargs": "^12.0.2"
@@ -2575,26 +2575,26 @@
           "dev": true
         },
         "jest-validate": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.3.1.tgz",
-          "integrity": "sha512-ww3+IPNCOEMi1oKlrHdSnBXetXtdrrdSh0bqLNTVkWglduhORf94RJWd1ko9oEPU2TcEQS5QIPacYziQIUzc4A==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
+          "integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "camelcase": "^5.0.0",
             "chalk": "^2.0.1",
             "jest-get-type": "^24.3.0",
             "leven": "^2.1.0",
-            "pretty-format": "^24.3.1"
+            "pretty-format": "^24.5.0"
           }
         },
         "pretty-format": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
-          "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+          "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "ansi-regex": "^4.0.0",
             "ansi-styles": "^3.2.0",
             "react-is": "^16.8.4"
@@ -2603,37 +2603,37 @@
       }
     },
     "jest-changed-files": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.3.0.tgz",
-      "integrity": "sha512-fTq0YAUR6644fgsqLC7Zi2gXA/bAplMRvfXQdutmkwgrCKK6upkj+sgXqsUfUZRm15CVr3YSojr/GRNn71IMvg==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.5.0.tgz",
+      "integrity": "sha512-Ikl29dosYnTsH9pYa1Tv9POkILBhN/TLZ37xbzgNsZ1D2+2n+8oEZS2yP1BrHn/T4Rs4Ggwwbp/x8CKOS5YJOg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.3.0",
+        "@jest/types": "^24.5.0",
         "execa": "^1.0.0",
         "throat": "^4.0.0"
       }
     },
     "jest-config": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.3.1.tgz",
-      "integrity": "sha512-ujHQywsM//vKFvJwEC02KNZgKAGOzGz1bFPezmTQtuj8XdfsAVq8p6N/dw4yodXV11gSf6TJ075i4ehM+mKatA==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.5.0.tgz",
+      "integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^24.3.0",
-        "babel-jest": "^24.3.1",
+        "@jest/types": "^24.5.0",
+        "babel-jest": "^24.5.0",
         "chalk": "^2.0.1",
         "glob": "^7.1.1",
-        "jest-environment-jsdom": "^24.3.1",
-        "jest-environment-node": "^24.3.1",
+        "jest-environment-jsdom": "^24.5.0",
+        "jest-environment-node": "^24.5.0",
         "jest-get-type": "^24.3.0",
-        "jest-jasmine2": "^24.3.1",
+        "jest-jasmine2": "^24.5.0",
         "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.3.1",
-        "jest-util": "^24.3.0",
-        "jest-validate": "^24.3.1",
+        "jest-resolve": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jest-validate": "^24.5.0",
         "micromatch": "^3.1.10",
-        "pretty-format": "^24.3.1",
+        "pretty-format": "^24.5.0",
         "realpath-native": "^1.1.0"
       },
       "dependencies": {
@@ -2644,26 +2644,26 @@
           "dev": true
         },
         "jest-validate": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.3.1.tgz",
-          "integrity": "sha512-ww3+IPNCOEMi1oKlrHdSnBXetXtdrrdSh0bqLNTVkWglduhORf94RJWd1ko9oEPU2TcEQS5QIPacYziQIUzc4A==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
+          "integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "camelcase": "^5.0.0",
             "chalk": "^2.0.1",
             "jest-get-type": "^24.3.0",
             "leven": "^2.1.0",
-            "pretty-format": "^24.3.1"
+            "pretty-format": "^24.5.0"
           }
         },
         "pretty-format": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
-          "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+          "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "ansi-regex": "^4.0.0",
             "ansi-styles": "^3.2.0",
             "react-is": "^16.8.4"
@@ -2672,15 +2672,15 @@
       }
     },
     "jest-diff": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.3.1.tgz",
-      "integrity": "sha512-YRVzDguyzShP3Pb9wP/ykBkV7Z+O4wltrMZ2P4LBtNxrHNpxwI2DECrpD9XevxWubRy5jcE8sSkxyX3bS7W+rA==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
+      "integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
         "diff-sequences": "^24.3.0",
         "jest-get-type": "^24.3.0",
-        "pretty-format": "^24.3.1"
+        "pretty-format": "^24.5.0"
       },
       "dependencies": {
         "jest-get-type": {
@@ -2690,12 +2690,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
-          "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+          "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "ansi-regex": "^4.0.0",
             "ansi-styles": "^3.2.0",
             "react-is": "^16.8.4"
@@ -2713,16 +2713,16 @@
       }
     },
     "jest-each": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.3.1.tgz",
-      "integrity": "sha512-GTi+nxDaWwSgOPLiiqb/p4LURy0mv3usoqsA2eoTYSmRsLgjgZ6VUyRpUBH5JY9EMBx33suNFXk0iyUm29WRpw==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.5.0.tgz",
+      "integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.3.0",
+        "@jest/types": "^24.5.0",
         "chalk": "^2.0.1",
         "jest-get-type": "^24.3.0",
-        "jest-util": "^24.3.0",
-        "pretty-format": "^24.3.1"
+        "jest-util": "^24.5.0",
+        "pretty-format": "^24.5.0"
       },
       "dependencies": {
         "jest-get-type": {
@@ -2732,12 +2732,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
-          "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+          "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "ansi-regex": "^4.0.0",
             "ansi-styles": "^3.2.0",
             "react-is": "^16.8.4"
@@ -2746,30 +2746,30 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.3.1.tgz",
-      "integrity": "sha512-rz2OSYJiQerDqWDwjisqRwhVNpwkqFXdtyMzEuJ47Ip9NRpRQ+qy7/+zFujPUy/Z+zjWRO5seHLB/dOD4VpEVg==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz",
+      "integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.3.1",
-        "@jest/fake-timers": "^24.3.0",
-        "@jest/types": "^24.3.0",
-        "jest-mock": "^24.3.0",
-        "jest-util": "^24.3.0",
+        "@jest/environment": "^24.5.0",
+        "@jest/fake-timers": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "jest-mock": "^24.5.0",
+        "jest-util": "^24.5.0",
         "jsdom": "^11.5.1"
       }
     },
     "jest-environment-node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.3.1.tgz",
-      "integrity": "sha512-Xy+/yFem/yUs9OkzbcawQT237vwDjBhAVLjac1KYAMYVjGb0Vb/Ovw4g61PunVdrEIpfcXNtRUltM4+9c7lARQ==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.5.0.tgz",
+      "integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.3.1",
-        "@jest/fake-timers": "^24.3.0",
-        "@jest/types": "^24.3.0",
-        "jest-mock": "^24.3.0",
-        "jest-util": "^24.3.0"
+        "@jest/environment": "^24.5.0",
+        "@jest/fake-timers": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "jest-mock": "^24.5.0",
+        "jest-util": "^24.5.0"
       }
     },
     "jest-get-type": {
@@ -2779,53 +2779,53 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.3.1.tgz",
-      "integrity": "sha512-OTMQle+astr1lWKi62Ccmk2YWn6OtUoU/8JpJdg8zdsnpFIry/k0S4sQ4nWocdM07PFdvqcthWc78CkCE6sXvA==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
+      "integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.3.0",
+        "@jest/types": "^24.5.0",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
-        "jest-serializer": "^24.3.0",
-        "jest-util": "^24.3.0",
-        "jest-worker": "^24.3.1",
+        "jest-serializer": "^24.4.0",
+        "jest-util": "^24.5.0",
+        "jest-worker": "^24.4.0",
         "micromatch": "^3.1.10",
         "sane": "^4.0.3"
       }
     },
     "jest-jasmine2": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.3.1.tgz",
-      "integrity": "sha512-STo6ar1IyPlIPq9jPxDQhM7lC0dAX7KKN0LmCLMlgJeXwX+1XiVdtZDv1a4zyg6qhNdpo1arOBGY0BcovUK7ug==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz",
+      "integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^24.3.1",
-        "@jest/test-result": "^24.3.0",
-        "@jest/types": "^24.3.0",
+        "@jest/environment": "^24.5.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/types": "^24.5.0",
         "chalk": "^2.0.1",
         "co": "^4.6.0",
-        "expect": "^24.3.1",
+        "expect": "^24.5.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^24.3.1",
-        "jest-matcher-utils": "^24.3.1",
-        "jest-message-util": "^24.3.0",
-        "jest-runtime": "^24.3.1",
-        "jest-snapshot": "^24.3.1",
-        "jest-util": "^24.3.0",
-        "pretty-format": "^24.3.1",
+        "jest-each": "^24.5.0",
+        "jest-matcher-utils": "^24.5.0",
+        "jest-message-util": "^24.5.0",
+        "jest-runtime": "^24.5.0",
+        "jest-snapshot": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "pretty-format": "^24.5.0",
         "throat": "^4.0.0"
       },
       "dependencies": {
         "pretty-format": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
-          "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+          "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "ansi-regex": "^4.0.0",
             "ansi-styles": "^3.2.0",
             "react-is": "^16.8.4"
@@ -2863,21 +2863,21 @@
       }
     },
     "jest-leak-detector": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.3.1.tgz",
-      "integrity": "sha512-GncRwEtAw/SohdSyY4bk2RE06Ac1dZrtQGZQ2j35hSuN4gAAAKSYMszJS2WDixsAEaFN+GHBHG+d8pjVGklKyw==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.5.0.tgz",
+      "integrity": "sha512-LZKBjGovFRx3cRBkqmIg+BZnxbrLqhQl09IziMk3oeh1OV81Hg30RUIx885mq8qBv1PA0comB9bjKcuyNO1bCQ==",
       "dev": true,
       "requires": {
-        "pretty-format": "^24.3.1"
+        "pretty-format": "^24.5.0"
       },
       "dependencies": {
         "pretty-format": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
-          "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+          "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "ansi-regex": "^4.0.0",
             "ansi-styles": "^3.2.0",
             "react-is": "^16.8.4"
@@ -2886,15 +2886,15 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.3.1.tgz",
-      "integrity": "sha512-P5VIsUTJeI0FYvWVMwEHjxK1L83vEkDiKMV0XFPIrT2jzWaWPB2+dPCHkP2ID9z4eUKElaHqynZnJiOdNVHfXQ==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
+      "integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
-        "jest-diff": "^24.3.1",
+        "jest-diff": "^24.5.0",
         "jest-get-type": "^24.3.0",
-        "pretty-format": "^24.3.1"
+        "pretty-format": "^24.5.0"
       },
       "dependencies": {
         "jest-get-type": {
@@ -2904,12 +2904,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
-          "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+          "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "ansi-regex": "^4.0.0",
             "ansi-styles": "^3.2.0",
             "react-is": "^16.8.4"
@@ -2918,14 +2918,14 @@
       }
     },
     "jest-message-util": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.3.0.tgz",
-      "integrity": "sha512-lXM0YgKYGqN5/eH1NGw4Ix+Pk2I9Y77beyRas7xM24n+XTTK3TbT0VkT3L/qiyS7WkW0YwyxoXnnAaGw4hsEDA==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
+      "integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@jest/test-result": "^24.3.0",
-        "@jest/types": "^24.3.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/types": "^24.5.0",
         "@types/stack-utils": "^1.0.1",
         "chalk": "^2.0.1",
         "micromatch": "^3.1.10",
@@ -2934,13 +2934,19 @@
       }
     },
     "jest-mock": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.3.0.tgz",
-      "integrity": "sha512-AhAo0qjbVWWGvcbW5nChFjR0ObQImvGtU6DodprNziDOt+pP0CBdht/sYcNIOXeim8083QUi9bC8QdKB8PTK4Q==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
+      "integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.3.0"
+        "@jest/types": "^24.5.0"
       }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+      "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+      "dev": true
     },
     "jest-regex-util": {
       "version": "24.3.0",
@@ -2949,80 +2955,81 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.3.1.tgz",
-      "integrity": "sha512-N+Q3AcVuKxpn/kjQMxUVLwBk32ZE1diP4MPcHyjVwcKpCUuKrktfRR3Mqe/T2HoD25wyccstaqcPUKIudl41bg==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.5.0.tgz",
+      "integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.3.0",
+        "@jest/types": "^24.5.0",
         "browser-resolve": "^1.11.3",
         "chalk": "^2.0.1",
+        "jest-pnp-resolver": "^1.2.1",
         "realpath-native": "^1.1.0"
       }
     },
     "jest-resolve-dependencies": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.3.1.tgz",
-      "integrity": "sha512-9JUejNImGnJjbNR/ttnod+zQIWANpsrYMPt18s2tYGK6rP191qFsyEQ2BhAQMdYDRkTmi8At+Co9tL+jTPqdpw==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.5.0.tgz",
+      "integrity": "sha512-dRVM1D+gWrFfrq2vlL5P9P/i8kB4BOYqYf3S7xczZ+A6PC3SgXYSErX/ScW/469pWMboM1uAhgLF+39nXlirCQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.3.0",
+        "@jest/types": "^24.5.0",
         "jest-regex-util": "^24.3.0",
-        "jest-snapshot": "^24.3.1"
+        "jest-snapshot": "^24.5.0"
       }
     },
     "jest-runner": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.3.1.tgz",
-      "integrity": "sha512-Etc9hQ5ruwg+q7DChm+E8qzHHdNTLeUdlo+whPQRSpNSgl0AEgc2r2mT4lxODREqmnHg9A8JHA44pIG4GE0Gzg==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.5.0.tgz",
+      "integrity": "sha512-oqsiS9TkIZV5dVkD+GmbNfWBRPIvxqmlTQ+AQUJUQ07n+4xTSDc40r+aKBynHw9/tLzafC00DIbJjB2cOZdvMA==",
       "dev": true,
       "requires": {
         "@jest/console": "^24.3.0",
-        "@jest/environment": "^24.3.1",
-        "@jest/test-result": "^24.3.0",
-        "@jest/types": "^24.3.0",
+        "@jest/environment": "^24.5.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/types": "^24.5.0",
         "chalk": "^2.4.2",
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.15",
-        "jest-config": "^24.3.1",
+        "jest-config": "^24.5.0",
         "jest-docblock": "^24.3.0",
-        "jest-haste-map": "^24.3.1",
-        "jest-jasmine2": "^24.3.1",
-        "jest-leak-detector": "^24.3.1",
-        "jest-message-util": "^24.3.0",
-        "jest-resolve": "^24.3.1",
-        "jest-runtime": "^24.3.1",
-        "jest-util": "^24.3.0",
-        "jest-worker": "^24.3.1",
+        "jest-haste-map": "^24.5.0",
+        "jest-jasmine2": "^24.5.0",
+        "jest-leak-detector": "^24.5.0",
+        "jest-message-util": "^24.5.0",
+        "jest-resolve": "^24.5.0",
+        "jest-runtime": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jest-worker": "^24.4.0",
         "source-map-support": "^0.5.6",
         "throat": "^4.0.0"
       }
     },
     "jest-runtime": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.3.1.tgz",
-      "integrity": "sha512-Qz/tJWbZ2naFJ2Kvy1p+RhhRgsPYh4e6wddVRy6aHBr32FTt3Ja33bfV7pkMFWXFbVuAsJMJVdengbvdhWzq4A==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.5.0.tgz",
+      "integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
       "dev": true,
       "requires": {
         "@jest/console": "^24.3.0",
-        "@jest/environment": "^24.3.1",
+        "@jest/environment": "^24.5.0",
         "@jest/source-map": "^24.3.0",
-        "@jest/transform": "^24.3.1",
-        "@jest/types": "^24.3.0",
+        "@jest/transform": "^24.5.0",
+        "@jest/types": "^24.5.0",
         "@types/yargs": "^12.0.2",
         "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.1.15",
-        "jest-config": "^24.3.1",
-        "jest-haste-map": "^24.3.1",
-        "jest-message-util": "^24.3.0",
-        "jest-mock": "^24.3.0",
+        "jest-config": "^24.5.0",
+        "jest-haste-map": "^24.5.0",
+        "jest-message-util": "^24.5.0",
+        "jest-mock": "^24.5.0",
         "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.3.1",
-        "jest-snapshot": "^24.3.1",
-        "jest-util": "^24.3.0",
-        "jest-validate": "^24.3.1",
+        "jest-resolve": "^24.5.0",
+        "jest-snapshot": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jest-validate": "^24.5.0",
         "realpath-native": "^1.1.0",
         "slash": "^2.0.0",
         "strip-bom": "^3.0.0",
@@ -3036,26 +3043,26 @@
           "dev": true
         },
         "jest-validate": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.3.1.tgz",
-          "integrity": "sha512-ww3+IPNCOEMi1oKlrHdSnBXetXtdrrdSh0bqLNTVkWglduhORf94RJWd1ko9oEPU2TcEQS5QIPacYziQIUzc4A==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
+          "integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "camelcase": "^5.0.0",
             "chalk": "^2.0.1",
             "jest-get-type": "^24.3.0",
             "leven": "^2.1.0",
-            "pretty-format": "^24.3.1"
+            "pretty-format": "^24.5.0"
           }
         },
         "pretty-format": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
-          "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+          "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "ansi-regex": "^4.0.0",
             "ansi-styles": "^3.2.0",
             "react-is": "^16.8.4"
@@ -3064,38 +3071,38 @@
       }
     },
     "jest-serializer": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.3.0.tgz",
-      "integrity": "sha512-RiSpqo2OFbVLJN/PgAOwQIUeHDfss6NBUDTLhjiJM8Bb5rMrwRqHfkaqahIsOf9cXXB5UjcqDCzbQ7AIoMqWkg==",
+      "version": "24.4.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+      "integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
       "dev": true
     },
     "jest-snapshot": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.3.1.tgz",
-      "integrity": "sha512-7wbNJWh0sBjmoaexTOWqS7nleTQME7o2W9XKU6CHCxG49Thjct4aVPC/QPNF5NHnvf4M/VDmudIDbwz6noJTRA==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.5.0.tgz",
+      "integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
-        "@jest/types": "^24.3.0",
+        "@jest/types": "^24.5.0",
         "chalk": "^2.0.1",
-        "expect": "^24.3.1",
-        "jest-diff": "^24.3.1",
-        "jest-matcher-utils": "^24.3.1",
-        "jest-message-util": "^24.3.0",
-        "jest-resolve": "^24.3.1",
+        "expect": "^24.5.0",
+        "jest-diff": "^24.5.0",
+        "jest-matcher-utils": "^24.5.0",
+        "jest-message-util": "^24.5.0",
+        "jest-resolve": "^24.5.0",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^24.3.1",
+        "pretty-format": "^24.5.0",
         "semver": "^5.5.0"
       },
       "dependencies": {
         "pretty-format": {
-          "version": "24.3.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
-          "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
+          "version": "24.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+          "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^24.3.0",
+            "@jest/types": "^24.5.0",
             "ansi-regex": "^4.0.0",
             "ansi-styles": "^3.2.0",
             "react-is": "^16.8.4"
@@ -3104,16 +3111,16 @@
       }
     },
     "jest-util": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.3.0.tgz",
-      "integrity": "sha512-eKIAC+MTKWZthUUVOwZ3Tc5a0cKMnxalQHr6qZ4kPzKn6k09sKvsmjCygqZ1SxVVfUKoa8Sfn6XDv9uTJ1iXTg==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
+      "integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
       "dev": true,
       "requires": {
         "@jest/console": "^24.3.0",
-        "@jest/fake-timers": "^24.3.0",
+        "@jest/fake-timers": "^24.5.0",
         "@jest/source-map": "^24.3.0",
-        "@jest/test-result": "^24.3.0",
-        "@jest/types": "^24.3.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/types": "^24.5.0",
         "@types/node": "*",
         "callsites": "^3.0.0",
         "chalk": "^2.0.1",
@@ -3146,25 +3153,25 @@
       }
     },
     "jest-watcher": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.3.0.tgz",
-      "integrity": "sha512-EpJS/aUG8D3DMuy9XNA4fnkKWy3DQdoWhY92ZUdlETIeEn1xya4Np/96MBSh4II5YvxwKe6JKwbu3Bnzfwa7vA==",
+      "version": "24.5.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.5.0.tgz",
+      "integrity": "sha512-/hCpgR6bg0nKvD3nv4KasdTxuhwfViVMHUATJlnGCD0r1QrmIssimPbmc5KfAQblAVxkD8xrzuij9vfPUk1/rA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^24.3.0",
-        "@jest/types": "^24.3.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/types": "^24.5.0",
         "@types/node": "*",
         "@types/yargs": "^12.0.9",
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.1",
-        "jest-util": "^24.3.0",
+        "jest-util": "^24.5.0",
         "string-length": "^2.0.0"
       }
     },
     "jest-worker": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.3.1.tgz",
-      "integrity": "sha512-ZCoAe/iGLzTJvWHrO8fyx3bmEQhpL16SILJmWHKe8joHhyF3z00psF1sCRT54DoHw5GJG0ZpUtGy+ylvwA4haA==",
+      "version": "24.4.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
+      "integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -3646,14 +3653,22 @@
       }
     },
     "mem": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
+      "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
       "dev": true,
       "requires": {
         "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^1.0.0",
+        "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
+          "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+          "dev": true
+        }
       }
     },
     "merge-stream": {
@@ -4812,9 +4827,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
-      "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+      "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "husky": "^1.3.1",
-    "jest": "^24.3.1",
+    "jest": "^24.5.0",
     "jest-junit": "^6.3.0",
     "lint-staged": "^8.1.5",
     "prettier": "^1.16.4"

--- a/processors/src/claim-processor/__tests__/payload.test.js
+++ b/processors/src/claim-processor/__tests__/payload.test.js
@@ -10,15 +10,21 @@ describe('ClaimPayload', () => {
    * @type {Readonly<Protos.Claim>}
    */
   const DATA = Object.freeze({
-    files: [],
     status: 0,
+    created: new Date(Date.UTC(2019, 0)).toJSON(),
+    modified: new Date(Date.UTC(2019, 0)).toJSON(),
+    date_of_loss: new Date(Date.UTC(2019, 0)).toJSON(),
     vehicle: {
       vin: '1234567890',
-      color: 'red',
       miles: 1000,
-      model: 'sedan',
-      year: 2019,
+      location: 'salvage',
     },
+    insurer: {
+      name: '',
+      deductible: 0,
+      has_gap: false,
+    },
+    files: [],
   });
 
   /**
@@ -48,11 +54,12 @@ describe('ClaimPayload', () => {
   });
 
   it('should resolve to default values when given partial payload and default = true', async () => {
-    const { color, year, model, ...data } = DATA.vehicle;
+    const { location, miles, ...data } = DATA.vehicle;
     const payload = await ClaimPayload.fromBytes(
       PayloadType.encode({
         action: Actions.CREATE_CLAIM,
         data: {
+          ...DATA,
           vehicle: {
             ...data,
           },
@@ -61,24 +68,22 @@ describe('ClaimPayload', () => {
       true,
     );
     expect(payload.data).toEqual({
-      files: [],
-      status: 0,
+      ...DATA,
       vehicle: {
         vin: '1234567890',
-        color: '',
-        miles: 1000,
-        model: '',
-        year: 0,
+        miles: 0,
+        location: '',
       },
     });
   });
 
   it('should not resolve to default values when given partial payload and default = false or undefined', async () => {
-    const { color, year, model, ...data } = DATA.vehicle;
+    const { location, miles, ...data } = DATA.vehicle;
     const payload = await ClaimPayload.fromBytes(
       PayloadType.encode({
         action: Actions.CREATE_CLAIM,
         data: {
+          ...DATA,
           vehicle: {
             ...data,
           },
@@ -86,10 +91,9 @@ describe('ClaimPayload', () => {
       }).finish(),
     );
     expect(payload.data).toEqual({
-      files: [],
+      ...DATA,
       vehicle: {
         vin: '1234567890',
-        miles: 1000,
       },
     });
   });

--- a/processors/src/claim-processor/__tests__/state.test.js
+++ b/processors/src/claim-processor/__tests__/state.test.js
@@ -10,15 +10,21 @@ describe('ClaimState', () => {
    * @type {Readonly<Protos.Claim>}
    */
   const DATA = Object.freeze({
-    files: [],
     status: 0,
+    created: new Date(Date.UTC(2019, 0)).toJSON(),
+    modified: new Date(Date.UTC(2019, 0)).toJSON(),
+    date_of_loss: new Date(Date.UTC(2019, 0)).toJSON(),
     vehicle: {
       vin: '1234567890',
-      color: 'red',
       miles: 1000,
-      model: 'sedan',
-      year: 2019,
+      location: 'salvage',
     },
+    insurer: {
+      name: '',
+      deductible: 0,
+      has_gap: false,
+    },
+    files: [],
   });
   const ADDRESS = addressFromVIN('1234567890');
   /**
@@ -53,26 +59,25 @@ describe('ClaimState', () => {
   });
 
   it('should serialize default values when given partial valid data', async () => {
-    const { year, color, ...vehicle } = DATA.vehicle;
-    const buffer = await state._serialize({ status: 1, vehicle });
+    const { location, miles, ...vehicle } = DATA.vehicle;
+    const buffer = await state._serialize({ ...DATA, vehicle: { ...vehicle } });
     const claim = await state._deserialize(buffer);
     expect(claim).toEqual({
-      files: [],
-      status: 1,
+      ...DATA,
       vehicle: {
         ...DATA.vehicle,
-        color: '',
-        year: 0,
+        miles: 0,
+        location: '',
       },
     });
   });
 
   it('should throw InvalidTransaction when given data of incorrect type', async () => {
     /** @type {any} */
-    let invalid = { ...DATA, vehicle: { ...DATA.vehicle, color: true } };
+    let invalid = { ...DATA, vehicle: { ...DATA.vehicle, location: true } };
     await expect(state._serialize(invalid)).rejects.toThrow(InvalidTransaction);
     await expect(state._serialize(invalid)).rejects.toThrow(
-      new InvalidTransaction('vehicle.color: string expected'),
+      new InvalidTransaction('vehicle.location: string expected'),
     );
 
     invalid = { ...DATA, vehicle: 42 };

--- a/processors/src/proto.js
+++ b/processors/src/proto.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 
-const { load } = require('protobufjs');
+const { Root } = require('protobufjs');
 
 const readdir = promisify(fs.readdir);
 
@@ -23,7 +23,8 @@ exports.loadRoot = async () => {
   const protos = await readdir(protosPath).then(files =>
     files.map(name => path.join(protosPath, name)),
   );
-  return load(protos);
+  const root = new Root();
+  return root.load(protos, { keepCase: true });
 };
 
 /**
@@ -32,7 +33,7 @@ exports.loadRoot = async () => {
  * @param {string} typename - The name of the type to load.
  * @return {Promise<ProtobufType>}
  */
-exports.loadType = async (typename) => {
+exports.loadType = async typename => {
   const Root = await exports.loadRoot();
   return Root.lookupType(typename);
 };

--- a/protos/claim.proto
+++ b/protos/claim.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "file.proto";
+import "insurer.proto";
 import "vehicle.proto";
 
 message Claim {
@@ -8,8 +9,7 @@ message Claim {
     // Initial data entry and settlement agreement being orchestrated by
     // the insurance company.
     SETTLEMENT = 0;
-    // Settlement has been reached. Information and files are being
-    // collected/requested by agencies exterior to insurance company
+    // Settlement has been reached. Information and files are being collected/requested by agencies exterior to insurance company
     // (DMV, Ford Credit, etc).
     DATA_COLLECTION = 1;
     // All required files have been obtained. Vehicle is ready for auction.
@@ -18,11 +18,24 @@ message Claim {
     RESOLVED = 3;
   }
 
-  Vehicle vehicle = 1;
-
   // The status of the vehicle in the system.
-  Status status = 2;
+  Status status = 1;
 
-  // An array of sha256 hex digests of the associated files stored in s3.
-  repeated File files = 3;
+  // JSON serialized UTC date representing claim creation time.
+  string created = 2;
+
+  // JSON serialized UTC date representing last modification time.
+  string modified = 3;
+
+  // JSON serialized UTC date representing the date of vehicle loss.
+  string date_of_loss = 4;
+
+  // The vehicle info.
+  Vehicle vehicle = 5;
+
+  // The insurer info.
+  Insurer insurer = 6;
+
+  // An array file protos.
+  repeated File files = 7;
 }

--- a/protos/file.proto
+++ b/protos/file.proto
@@ -8,6 +8,23 @@ message File {
     ARCHIVED = 1;
   }
 
+  enum Type {
+    // Misc documents/images.
+    NONE = 0;
+    // Power of Attorney.
+    POA = 1;
+    // Vehicle title.
+    TITLE = 2;
+    // Odometer disclosure statement.
+    ODS = 3;
+    // Police report.
+    POLICE = 4;
+    // Settlement offer.
+    SETTLEMENT = 5;
+    // Letter of guarantee.
+    LOG = 6;
+  }
+
   // The computed hash of the file (the Amazon S3 `ETag`).
   string hash = 1;
 
@@ -16,4 +33,7 @@ message File {
 
   // The file's status.
   Status status = 3;
+
+  // The file's type.
+  Type type = 4;
 }

--- a/protos/insurer.proto
+++ b/protos/insurer.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+message Insurer {
+  // Name of insurance company.
+  string name = 1;
+
+  // Deductible amount.
+  uint32 deductible = 2;
+
+  // Whether or not owner has gap coverage.
+  bool has_gap = 3;
+}

--- a/protos/payload.proto
+++ b/protos/payload.proto
@@ -4,8 +4,8 @@ import "claim.proto";
 
 message ClaimPayload {
   enum Action {
-    // Never used on purpose.
-    // This ensures that payload actions are always specified explicitly.
+    // Ensures that payload actions are always specified explicitly. Should
+    // not be used on purpose.
     ERROR = 0;
     // Create a new claim.
     CREATE_CLAIM = 1;

--- a/protos/vehicle.proto
+++ b/protos/vehicle.proto
@@ -4,15 +4,9 @@ message Vehicle {
   // The vehicle VIN.
   string vin = 1;
 
-  // The vehicle model.
-  string model = 2;
-
-  // The vehicle year.
-  uint32 year = 3;
-
   // The vehicle's miles.
-  uint32 miles = 4;
+  uint32 miles = 2;
 
-  // The vehicle color.
-  string color = 5;
+  // Current location of the vehicle.
+  string location = 3;
 }

--- a/types/protos.d.ts
+++ b/types/protos.d.ts
@@ -1,41 +1,167 @@
 declare namespace Protos {
-  namespace File {
+  namespace Claim {
     enum Status {
-      ACTIVE,
-      ARCHIVED,
+      /**
+       * Initial data entry and settlement agreement being orchestrated by the
+       * insurance company.
+       */
+      SETTLEMENT,
+      /**
+       * Settlement has been reached. Information and files are being
+       * collected/requested by agencies exterior to insurance company (DMV,
+       * Ford Credit, etc).
+       */
+      DATA_COLLECTION,
+      /**
+       * All required files have been obtained. Vehicle is ready for auction.
+       */
+      AUCTION,
+      /**
+       * Vehicle has passed auction phase. Case has now been fully resolved.
+       */
+      RESOLVED,
     }
   }
-  interface File {
-    status: File.Status;
-    hash: string;
-    name: string;
-  }
-
   interface Claim {
-    files: File[];
-    status: number;
+    /**
+     * The status of the vehicle in the system.
+     */
+    status: Claim.Status;
+    /**
+     * JSON serialized UTC date representing claim creation time.
+     */
+    created: string;
+    /**
+     * JSON serialized UTC date representing last modification time.
+     */
+    modified: string;
+    /**
+     * JSON serialized UTC date representing the date of vehicle loss.
+     */
+    date_of_loss: string;
+    /**
+     * The vehicle info.
+     */
     vehicle: Vehicle;
-  }
-
-  interface Vehicle {
-    vin: string;
-    model: string;
-    year: number;
-    miles: number;
-    color: string;
-    //acv: number;
+    /**
+     * The insurer info.
+     */
+    insurer: Insurer;
+    /**
+     * An array of file protos.
+     */
+    files: File[];
   }
 
   namespace ClaimPayload {
     enum Action {
+      /**
+       * Ensures that payload actions are always specified explicitly. Should not be used on purpose.
+       */
       ERROR,
+      /**
+       * Create a new claim.
+       */
       CREATE_CLAIM,
+      /**
+       * Delete an existing claim.
+       */
       DELETE_CLAIM,
+      /**
+       * Edit an existing claim.
+       */
       EDIT_CLAIM,
     }
   }
   interface ClaimPayload {
+    /**
+     * Action to be taken.
+     */
     action: ClaimPayload.Action;
+    /**
+     * Claim data associated with the action.
+     */
     data: Claim;
   }
+
+  namespace File {
+    enum Status {
+      /**
+       * File is active and visible.
+       */
+      ACTIVE,
+      /**
+       * File has been archived by the user.
+       */
+      ARCHIVED,
+    }
+    enum Type {
+      /**
+       * Misc documents/images.
+       */
+      NONE,
+      /**
+       * Power of Attorney.
+       */
+      POA,
+      /**
+       * Vehicle title.
+       */
+      TITLE,
+      /**
+       * Odometer disclosure statement.
+       */
+      ODS,
+      /**
+       * Police report.
+       */
+      POLICE,
+      /**
+       * Settlement offer.
+       */
+      SETTLEMENT,
+      /**
+       * Letter of guarantee.
+       */
+      LOG,
+    }
+  }
+  interface File {
+    hash: string;
+    name: string;
+    status: File.Status;
+    type: File.Type;
+  }
+
+  interface Insurer {
+    /**
+     * Name of insurance company.
+     */
+    name: string;
+    /**
+     * Deductible amount.
+     */
+    deductible: number;
+    /**
+     * Whether or not owner has gap coverage.
+     */
+    has_gap: boolean;
+  }
+
+  interface Vehicle {
+    /**
+     * The vehicle VIN.
+     */
+    vin: string;
+    /**
+     * The vehicle's miles.
+     */
+    miles: number;
+    /**
+     * Current location of the vehicle.
+     */
+    location: string;
+  }
 }
+
+// vim: set fdn=2 fdl=1:


### PR DESCRIPTION
**Note:** The timestamp types can't easily be parsed as a number in protobufs, so instead I used a string. The type of string they should be is a JSON serialized UTC date. For example...

```js
const serializedDate = new Date(Date.UTC(2019, 0)).toJSON();
```

Parsing this back into a usable JavaScript date is as easy as doing this...

```js
const jsDate = new Date(serializedDate);
```

Let me know if you have any questions.