### PR TITLE
Seamus Tasks (Elevation, Buttons, Spacing)

### DIFF
--- a/frontend/insurance/src/app/core/components/navigation-bar/navigation-bar.component.html
+++ b/frontend/insurance/src/app/core/components/navigation-bar/navigation-bar.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar color="primary">
+<mat-toolbar color="primary" class="mat-elevation-z6">
   <mat-toolbar-row>
     <button mat-button (click)="themeButton()">
       Change Theme

--- a/frontend/insurance/src/app/core/components/navigation-bar/navigation-bar.component.html
+++ b/frontend/insurance/src/app/core/components/navigation-bar/navigation-bar.component.html
@@ -1,6 +1,6 @@
 <mat-toolbar color="primary">
   <mat-toolbar-row>
-    <button mat-raised-button color="accent" (click)="themeButton()">
+    <button mat-button (click)="themeButton()">
       Change Theme
     </button>
     <span class="header-spacer"></span>
@@ -8,23 +8,13 @@
       Insurance Viewer
     </h1>
     <span class="header-spacer"></span>
-    <button
-      mat-raised-button
-      *ngIf="auth.isLoggedIn"
-      (click)="auth.logout()"
-      color="accent"
-    >
+    <button mat-button *ngIf="auth.isLoggedIn" (click)="auth.logout()">
       Log Out
     </button>
-    <button
-      mat-raised-button
-      *ngIf="!auth.isLoggedIn"
-      (click)="auth.login()"
-      color="accent"
-    >
+    <button mat-button *ngIf="!auth.isLoggedIn" (click)="auth.login()">
       Log In
     </button>
-    <button mat-button [routerLink]="['']" color="background">
+    <button mat-button [routerLink]="['']">
       <mat-icon>home</mat-icon>
     </button>
   </mat-toolbar-row>

--- a/frontend/insurance/src/app/modules/view-claims/view-claims.component.html
+++ b/frontend/insurance/src/app/modules/view-claims/view-claims.component.html
@@ -2,7 +2,7 @@
   <div class="center-to-page add-view-button">
     <a routerLink="/claims/new">
       <button mat-raised-button color="accent" class="width-100 ptm pbm">
-        Add A New Claim
+        Create New Claim
       </button>
     </a>
   </div>
@@ -32,7 +32,7 @@
     [dataSource]="dataSource"
     multiTemplateDataRows
     matSort
-    class="mat-elevation-z8"
+    class="mat-elevation-z3"
   >
     <ng-container matColumnDef="status">
       <th mat-header-cell *matHeaderCellDef>Status</th>
@@ -90,39 +90,39 @@
         [attr.colspan]="columnsToDisplay.length"
       >
         <div
-          class="example-element-detail"
+          class="example-element-detail width-100"
           [@detailExpand]="
             element == expandedElement ? 'expanded' : 'collapsed'
           "
         >
-          <div class="mtl mbl width-100">
-            <mat-list class="vehicle-information">
-              <div class="content-wrapper mbn">
-                <div class="row">
-                  <div class="column">
-                    <div class="one-column">
-                      <mat-list-item>
-                        <p class="label-text">
-                          Miles: {{ element.vehicle.miles }}
-                        </p>
-                      </mat-list-item>
-                      <mat-list-item>
-                        <a routerLink="/claims/{{ element.vehicle.vin }}">
-                          <button mat-raised-button color="accent">
-                            Edit Claim
-                          </button>
-                        </a>
-                      </mat-list-item>
-                    </div>
+          <div class="width-100">
+            <mat-list class="width-100" style="padding-top: 0;">
+              <div class="content-wrapper">
+                <div class="row width-100">
+                  <div class="one-column left-expand mlh">
+                    <mat-list-item>
+                      <a routerLink="/claims/{{ element.vehicle.vin }}">
+                        <button mat-raised-button color="accent">
+                          Edit Claim
+                        </button>
+                      </a>
+                    </mat-list-item>
                   </div>
-                  <div class="column">
-                    <div class="two-column">
-                      <mat-list-item>
-                        <p class="label-text">
-                          Vehicle Location: {{ element.vehicle.location }}
-                        </p>
-                      </mat-list-item>
-                    </div>
+
+                  <div class="one-column left-expand">
+                    <mat-list-item>
+                      <p class="label-text">
+                        Miles: {{ element.vehicle.miles }}
+                      </p>
+                    </mat-list-item>
+                  </div>
+
+                  <div class="one-column left-expand">
+                    <mat-list-item>
+                      <p class="label-text">
+                        Vehicle Location: {{ element.vehicle.location }}
+                      </p>
+                    </mat-list-item>
                   </div>
                 </div>
               </div>

--- a/frontend/insurance/src/app/modules/view-claims/view-claims.component.html
+++ b/frontend/insurance/src/app/modules/view-claims/view-claims.component.html
@@ -1,7 +1,7 @@
-<div>
-  <div class="center-to-page width-50">
-    <a routerLink="/claims/new" class="width-100">
-      <button mat-raised-button color="accent" class="width-100 mtl ptm pbm">
+<div class="mtl">
+  <div class="center-to-page add-view-button">
+    <a routerLink="/claims/new">
+      <button mat-raised-button color="accent" class="width-100 ptm pbm">
         Add A New Claim
       </button>
     </a>
@@ -20,10 +20,10 @@
       disableOptionCentering
       [value]="0"
     >
-      <mat-option [value]="0">Awaiting Settlement Option</mat-option>
-      <mat-option [value]="1">Finalize Loss</mat-option>
-      <mat-option [value]="2">At Auction</mat-option>
-      <mat-option [value]="3">Claim Resolved</mat-option>
+      <mat-option [value]="0">0 - Awaiting Settlement Option</mat-option>
+      <mat-option [value]="1">1 - Finalize Loss</mat-option>
+      <mat-option [value]="2">2 - At Auction</mat-option>
+      <mat-option [value]="3">3 - Claim Resolved</mat-option>
     </mat-select>
   </mat-form-field>
 
@@ -32,7 +32,7 @@
     [dataSource]="dataSource"
     multiTemplateDataRows
     matSort
-    class="mat-elevation-z24"
+    class="mat-elevation-z8"
   >
     <ng-container matColumnDef="status">
       <th mat-header-cell *matHeaderCellDef>Status</th>

--- a/frontend/insurance/src/app/modules/view-claims/view-claims.component.scss
+++ b/frontend/insurance/src/app/modules/view-claims/view-claims.component.scss
@@ -19,6 +19,7 @@ tr.example-element-row:not(.example-expanded-row):active {
 }
 
 .example-element-detail {
+  float: left;
   overflow: hidden;
   display: flex;
 }
@@ -55,4 +56,19 @@ tr.example-element-row:not(.example-expanded-row):active {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.left-expand {
+  width: 25%;
+  height: auto;
+}
+
+.right-expand {
+  width: 33%;
+  height: auto;
+}
+
+.center-expand {
+  width: 33%;
+  height: auto;
 }

--- a/frontend/insurance/src/app/modules/view-claims/view-claims.component.ts
+++ b/frontend/insurance/src/app/modules/view-claims/view-claims.component.ts
@@ -54,7 +54,6 @@ export class ViewClaimsComponent implements OnInit {
   }
 
   sortClaims(num: any) {
-    console.log(num);
     this.defaultFilter();
 
     this.dataSource.filter = num.toString();

--- a/frontend/insurance/src/app/shared/components/edit-claim/edit-claim.component.html
+++ b/frontend/insurance/src/app/shared/components/edit-claim/edit-claim.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="claim" class="width-100">
   <h1>VIN: {{ claim.vehicle.vin }}</h1>
-  <mat-list class="vehicle-information mbl">
+  <mat-list class="mbl mat-elevation-z4">
     <h2 class="mll">Vehicle Information</h2>
     <form [formGroup]="vehicleForm">
       <div class="content-wrapper">
@@ -69,7 +69,7 @@
       </div>
     </form>
   </mat-list>
-  <mat-list class="vehicle-information mbl pbm">
+  <mat-list class="mbl mat-elevation-z4 pbh">
     <h2 class="mll">Files on Claim</h2>
     <app-files
       [claim]="claim"
@@ -80,7 +80,7 @@
       <table
         mat-table
         [dataSource]="dataSource"
-        class="mat-elevation-z8 width-100 mtl"
+        class="mat-elevation-z6 file-table mtl mrm mlm pbl"
       >
         <!-- Position Column -->
         <ng-container matColumnDef="filename">
@@ -107,7 +107,7 @@
       </table>
     </div>
   </mat-list>
-  <mat-list class="vehicle-information mbl">
+  <mat-list class="mbl mat-elevation-z4">
     <h2 class="mll">Insurer Information</h2>
     <form [formGroup]="insurerForm">
       <div class="content-wrapper">
@@ -172,10 +172,10 @@
       </div>
     </form>
   </mat-list>
-  <mat-list class="vehicle-information mbl">
+  <mat-list>
     <mat-grid-list cols="3" rowHeight="100px">
       <mat-grid-tile>
-        <a class="width-50">
+        <a class="width-100">
           <button
             mat-raised-button
             color="accent"
@@ -183,19 +183,19 @@
             (click)="claimBackward()"
             [disabled]="claim.status === 0"
           >
-            <mat-icon>arrow_back</mat-icon>
+            Regress
           </button>
         </a>
       </mat-grid-tile>
       <mat-grid-tile>
-        <a (click)="deleteClaim()" class="width-50">
+        <a (click)="deleteClaim()" class="width-100">
           <button mat-raised-button color="warn" class="width-100">
-            <mat-icon>cancel</mat-icon>
+            DELETE CLAIM
           </button>
         </a>
       </mat-grid-tile>
       <mat-grid-tile>
-        <a class="width-50">
+        <a class="width-100">
           <button
             mat-raised-button
             color="accent"
@@ -203,7 +203,7 @@
             (click)="claimForward()"
             [disabled]="claim.status === 3"
           >
-            <mat-icon>arrow_forward</mat-icon>
+            Advance
           </button>
         </a>
       </mat-grid-tile>

--- a/frontend/insurance/src/app/shared/components/edit-claim/edit-claim.component.html
+++ b/frontend/insurance/src/app/shared/components/edit-claim/edit-claim.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="claim" class="width-100">
   <h1>VIN: {{ claim.vehicle.vin }}</h1>
-  <mat-list class="mbl mat-elevation-z4">
+  <mat-list class="mbl mat-elevation-z3">
     <h2 class="mll">Vehicle Information</h2>
     <form [formGroup]="vehicleForm">
       <div class="content-wrapper">
@@ -69,7 +69,7 @@
       </div>
     </form>
   </mat-list>
-  <mat-list class="mbl mat-elevation-z4 pbh">
+  <mat-list class="mbl mat-elevation-z3 pbh">
     <h2 class="mll">Files on Claim</h2>
     <app-files
       [claim]="claim"
@@ -107,7 +107,7 @@
       </table>
     </div>
   </mat-list>
-  <mat-list class="mbl mat-elevation-z4">
+  <mat-list class="mbl mat-elevation-z3">
     <h2 class="mll">Insurer Information</h2>
     <form [formGroup]="insurerForm">
       <div class="content-wrapper">
@@ -147,7 +147,7 @@
                 <p class="label-text">Deductible Amount ($):</p>
                 <span class="mls">
                   <input
-                    type="text"
+                    type="decimal"
                     class="raw-text-input editable-text"
                     [value]="claim.insurer.deductible"
                     formControlName="deductible"
@@ -183,7 +183,7 @@
             (click)="claimBackward()"
             [disabled]="claim.status === 0"
           >
-            Regress
+            Regress Status
           </button>
         </a>
       </mat-grid-tile>
@@ -203,7 +203,7 @@
             (click)="claimForward()"
             [disabled]="claim.status === 3"
           >
-            Advance
+            Advance Status
           </button>
         </a>
       </mat-grid-tile>

--- a/frontend/insurance/src/app/shared/components/edit-claim/edit-claim.component.scss
+++ b/frontend/insurance/src/app/shared/components/edit-claim/edit-claim.component.scss
@@ -2,3 +2,12 @@
   outline: 0px solid transparent;
   border-bottom: 2px solid darkgray;
 }
+
+.file-table {
+  width: 98%;
+}
+
+.editable-text:hover {
+  background: rgba(211, 211, 211, 0.6);
+  cursor: pointer;
+}

--- a/frontend/insurance/src/app/shared/components/edit-claim/edit-claim.component.ts
+++ b/frontend/insurance/src/app/shared/components/edit-claim/edit-claim.component.ts
@@ -160,7 +160,7 @@ export class EditClaimSharedComponent implements OnInit {
         name: this.insurerForm.controls['insurerName'].value
           ? this.insurerForm.controls['insurerName'].value
           : this.claim.insurer.name,
-        has_gap: this.insurerForm.controls['gap'].value
+        has_gap: Boolean(this.insurerForm.controls['gap'].value)
           ? this.gapValue
           : this.claim.insurer.has_gap,
         deductible: this.insurerForm.controls['deductible'].value
@@ -245,7 +245,7 @@ export class EditClaimSharedComponent implements OnInit {
 
           this.snackBar.open(
             `Claim status updated to: ${this.claim.status}`,
-            'Exit',
+            'OK',
             {
               duration: 5000,
             },

--- a/frontend/insurance/src/app/shared/components/new-claim/new-claim.component.html
+++ b/frontend/insurance/src/app/shared/components/new-claim/new-claim.component.html
@@ -1,5 +1,5 @@
 <div class="mtl">
-  <div class="center-to-page mat-elevation-z4 add-view-button">
+  <div class="center-to-page mat-elevation-z3 add-view-button">
     <button
       mat-raised-button
       color="accent"
@@ -10,7 +10,7 @@
     </button>
   </div>
   <div class="mth">
-    <mat-card class="width-50 center-to-page mat-elevation-z4">
+    <mat-card class="width-50 center-to-page mat-elevation-z3">
       <form>
         <mat-form-field
           class="width-100"

--- a/frontend/insurance/src/app/shared/components/new-claim/new-claim.component.html
+++ b/frontend/insurance/src/app/shared/components/new-claim/new-claim.component.html
@@ -1,5 +1,5 @@
 <div class="mtl">
-  <div class="center-to-page mat-elevation-z8" style="width: 53%">
+  <div class="center-to-page mat-elevation-z4 add-view-button">
     <button
       mat-raised-button
       color="accent"
@@ -10,7 +10,7 @@
     </button>
   </div>
   <div class="mth">
-    <mat-card class="width-50 center-to-page mat-elevation-z8">
+    <mat-card class="width-50 center-to-page mat-elevation-z4">
       <form>
         <mat-form-field
           class="width-100"

--- a/frontend/insurance/src/sass/core/edit-claim.scss
+++ b/frontend/insurance/src/sass/core/edit-claim.scss
@@ -1,10 +1,5 @@
 @import '../theme.scss';
 
-.vehicle-information {
-  border: 1px solid darkgray;
-  border-radius: 5px;
-}
-
 .edit-field {
   color: darkgray;
 }

--- a/frontend/insurance/src/sass/core/edit-claim.scss
+++ b/frontend/insurance/src/sass/core/edit-claim.scss
@@ -38,3 +38,7 @@
 .editable-text {
   color: mat-color($tlp-dark-accent) !important;
 }
+
+.add-view-button {
+  width: 53%;
+}

--- a/frontend/insurance/src/sass/spacing/spacing.scss
+++ b/frontend/insurance/src/sass/spacing/spacing.scss
@@ -54,6 +54,10 @@
   padding-left: 4px !important;
 }
 
+.prs {
+  padding-right: 4px !important;
+}
+
 .ptm {
   padding-top: 8px !important;
 }

--- a/frontend/insurance/src/sass/theme.scss
+++ b/frontend/insurance/src/sass/theme.scss
@@ -1,20 +1,49 @@
 @import '~@angular/material/theming';
+@import url('https://fonts.googleapis.com/css?family=Roboto');
+
+// Define a custom typography config that overrides the font-family as well as the
+// `headlines` and `body-1` levels.
+$custom-typography: mat-typography-config(
+  $font-family: 'Roboto - Sans Serif',
+  $display-4: mat-typography-level(112px, 112px, 300),
+  $display-3: mat-typography-level(56px, 56px, 400),
+  $display-2: mat-typography-level(45px, 48px, 400),
+  $display-1: mat-typography-level(34px, 40px, 400),
+  $headline: mat-typography-level(24px, 32px, 400),
+  $title: mat-typography-level(20px, 32px, 500),
+  $subheading-2: mat-typography-level(16px, 28px, 400),
+  $subheading-1: mat-typography-level(15px, 24px, 400),
+  $body-2: mat-typography-level(14px, 24px, 500),
+  $body-1: mat-typography-level(14px, 20px, 400),
+  $caption: mat-typography-level(12px, 20px, 400),
+  $button: mat-typography-level(14px, 14px, 500),
+  $input: mat-typography-level(inherit, 1.125, 400),
+);
+
+@include mat-base-typography($custom-typography);
+
+// Override typography for a specific Angular Material components.
+@include mat-checkbox-typography($custom-typography);
+
+// Override typography for all Angular Material, including mat-base-typography and all components.
+@include angular-material-typography($custom-typography);
 
 @include mat-core();
 
+// Color Scheme - Light
 $tlp-light-primary: mat-palette($mat-blue, 900);
 $tlp-light-accent: mat-palette($mat-blue, 800);
 $tlp-light-theme: mat-light-theme($tlp-light-primary, $tlp-light-accent);
 @include angular-material-theme($tlp-light-theme);
 
+// Color Scheme - Dark
 $tlp-dark-primary: mat-palette($mat-blue, 800);
 $tlp-dark-accent: mat-palette($mat-blue, 600);
 $tlp-dark-background-color: map_get($mat-blue-grey, 900);
 
-// Create the theme object (a Sass map containing all of the palettes).
 $theme: mat-dark-theme($tlp-dark-primary, $tlp-dark-accent);
 
-// Insert custom background color
+// Color Scheme - Set Background
 $background: map-get($theme, background);
 $background: map_merge(
   $background,
@@ -29,9 +58,6 @@ $theme: map_merge(
   )
 );
 
-// Include theme styles for core and each component used in your app.
-// Alternatively, you can import and @include the theme mixins for each component
-// that you are using.
 .alternative {
   @include angular-material-theme($theme);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1192,9 +1192,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
Fixed the elevation issues (?) in all pages.
	- All pages now start with elevation 4
	- Elements with elements on top now use the the elevation + 2 (i.e. file table in edit claims is on z6)

Fixed buttons on navigation toolbar
	- Buttons now blend in with the toolbar

Fixed spacing in edit claims
	- File section now looks similar to the other sections in terms of spacing

Additional:
	- Removed the icons from the arrow/delete buttons in edit claim (Text is clearer)